### PR TITLE
Incorporate extesy/hoverzoom/pull/797

### DIFF
--- a/js/hoverzoom.js
+++ b/js/hoverzoom.js
@@ -1710,6 +1710,10 @@ var hoverZoom = {
                         if (hoverZoomSrcIndex < link.data().hoverZoomSrc.length - 1) {
                             link.data().hoverZoomSrcIndex++;
                             preloadIndex--;
+                        } else {
+                            // all attempts to pre-load img have failed and there are no more src to try, 
+                            // so tag img as preloaded and move to next img
+                            link.data().hoverZoomPreloaded = true;
                         }
                         setTimeout(preloadNextImage, preloadDelay);
                     });


### PR DESCRIPTION
https://github.com/extesy/hoverzoom/pull/797 this change addresses https://github.com/extesy/hoverzoom/issues/794 this issue which causes HZ to make hundreds of thousands of repeated requests per hour to websites where it malforms the full-size URL, due to infinite-looping if it can't find the src.